### PR TITLE
rm cfg and toml entrypoint clash + renamed ids

### DIFF
--- a/napari-loadafm/src/napari_topostats/napari.yaml
+++ b/napari-loadafm/src/napari_topostats/napari.yaml
@@ -1,4 +1,4 @@
-name: napari-loadafm
+name: napari-TopoStats
 display_name: TopoStats
 # use 'hidden' to remove plugin from napari hub search results
 visibility: public
@@ -6,53 +6,53 @@ visibility: public
 categories: ["Annotation", "Segmentation", "Acquisition"]
 contributions:
   commands:
-    - id: napari-loadafm.get_reader
+    - id: napari-TopoStats.get_reader
       python_name: napari_topostats._reader:napari_get_reader
       title: Open data with TopoStats
-    - id: napari-loadafm.make_3d_widget
+    - id: napari-TopoStats.make_3d_widget
       python_name: napari_topostats:show_3d_autogenerate_widget
       title: Turn 2D image into 3D stack
 
-    - id: napari-loadafm.write_multiple
+    - id: napari-TopoStats.write_multiple
       python_name: napari_topostats._writer:write_multiple
       title: Save multi-layer data with TopoStats
-    - id: napari-loadafm.write_single_image
+    - id: napari-TopoStats.write_single_image
       python_name: napari_topostats._writer:write_single_image
       title: Save image data with TopoStats
-    - id: napari-loadafm.make_sample_data
+    - id: napari-TopoStats.make_sample_data
       python_name: napari_topostats._sample_data:make_sample_data
       title: Load sample data from TopoStats
-    - id: napari-loadafm.make_container_widget
+    - id: napari-TopoStats.make_container_widget
       python_name: napari_topostats:ImageThreshold
       title: Make threshold Container widget
-    - id: napari-loadafm.make_magic_widget
+    - id: napari-TopoStats.make_magic_widget
       python_name: napari_topostats:threshold_magic_widget
       title: Make threshold magic widget
 
-    - id: napari-loadafm.make_qwidget
+    - id: napari-TopoStats.make_qwidget
       python_name: napari_topostats:ExampleQWidget
       title: Make example QWidget
   readers:
-    - command: napari-loadafm.get_reader
+    - command: napari-TopoStats.get_reader
       accepts_directories: false
       filename_patterns: ['*.spm', '*.jpk', '*.ibw', '*.gwy', '*.topostats']
   writers:
-    - command: napari-loadafm.write_multiple
+    - command: napari-TopoStats.write_multiple
       layer_types: ['image*','labels*']
       filename_extensions: []
   sample_data:
-    - command: napari-loadafm.make_sample_data
+    - command: napari-TopoStats.make_sample_data
       display_name: TopoStats
       key: unique_id.1
   widgets:
-    - command: napari-loadafm.make_container_widget
+    - command: napari-TopoStats.make_container_widget
       display_name: Container Threshold
     - command: napari-loadafm.make_magic_widget
       display_name: Magic Threshold
 
-    - command: napari-loadafm.make_3d_widget
+    - command: napari-TopoStats.make_3d_widget
       autogenerate: true
       display_name: 3D-ify Image
 
-    - command: napari-loadafm.make_qwidget
+    - command: napari-TopoStats.make_qwidget
       display_name: Example QWidget

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,6 @@ exclude = [
 target-version = "py38"
 fix = true
 
-[project.entry-points."napari.manifest"]
+#[project.entry-points."napari.manifest"]
 #napari-loadafm = "napari-loadafm.napari.yaml"
 #napari-saveafm = "napari-saveafm.napari.yaml"


### PR DESCRIPTION
Commented out the line causing a clash between the two config file entrypoints and thus not finding the plugin.

Also fixed a bug where the plugin attemoeted to load but the names of the project in `napari.yaml` had to match that of the project.

- should be good to install now 🤞