### PR TITLE
Uncomment napari loadafm and chg dependancy to [all]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
   "magicgui",
-  "napari",
+  "napari[all]",
   "qtpy",
   "topostats",
   "tox"
@@ -114,5 +114,5 @@ target-version = "py38"
 fix = true
 
 #[project.entry-points."napari.manifest"]
-#napari-loadafm = "napari-loadafm.napari.yaml"
+napari-loadafm = "napari-loadafm.napari.yaml"
 #napari-saveafm = "napari-saveafm.napari.yaml"


### PR DESCRIPTION
Fixes #12 

Uncomments a line defining napari-loadafm
Replaces the napari dependancy with naparil[all] so the pyqt library is included