### PR TITLE
Adding napari entry point to pyproject.toml so plugin can be detected

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,3 +171,6 @@ filterwarnings = [
     "ignore::UserWarning"
 ]
 xfail_strict = true
+
+[project.entry-points."napari.manifest"]
+napari-TopoStats = "napari_topostats:napari.yaml"


### PR DESCRIPTION
Just installed the main branch in clean enviroment and looks like napari needs an entry point in pyproject.toml or setup.cfg in order to detect it as a plugin which turns out was in the old setup.cfg file. Moved that to the pyproject.toml file so napari detects the plugin.

---

Before submitting a Pull Request please check the following.

- [x] Make sure all existing tests pass.
- [x] Documentation has been updated and builds.
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [x] New functions/methods have tests which check the intended behaviour is correct.
